### PR TITLE
Add tag backup : easier backup management

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ A trivial example:
       roles:
         - { role: sfromm.mariadb }
         
+Use to deploy backup script
+---------------------------
+
+By setting **mariadb_do_backup** to true, and all the mariadb_*_backup variables or let them to default,
+
+you can deploy *only* backup script by playing the role with the tag "backup"
+
+A trivial example:
+
+    - hosts: servers
+      roles:
+        - { role: sfromm.mariadb }
+      tags: backup
+
+Will only deploy backup script and crontab
+
 License
 -------
 

--- a/tasks/backup.yml
+++ b/tasks/backup.yml
@@ -1,0 +1,18 @@
+---
+
+- name: deploy backup script
+  template: >-
+    src=mariadb-backup.sh.j2
+    dest={{ mariadb_backup_install_path }}/mariadb-backup
+    owner=root
+    group=root
+    mode=0755
+
+- name: create cron job for backups
+  cron: >-
+    name="mariadb backups"
+    hour=6
+    minute=5
+    user="root"
+    job="{{ mariadb_backup_install_path }}/mariadb-backup"
+    cron_file="ansible-mariadb-backup"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,24 +37,10 @@
     group={{ mariadb_owner }}
     mode=0644
 
-- name: deploy backup script
-  template: >-
-    src=mariadb-backup.sh.j2
-    dest={{ mariadb_backup_install_path }}/mariadb-backup
-    owner=root
-    group=root
-    mode=0755
+- name: deploy backup
+  include_tasks: backup.yml
   when: mariadb_do_backup
-
-- name: create cron job for backups
-  cron: >-
-    name="mariadb backups"
-    hour=6
-    minute=5
-    user="root"
-    job="{{ mariadb_backup_install_path }}/mariadb-backup"
-    cron_file="ansible-mariadb-backup"
-  when: mariadb_do_backup
+  tags: backup
 
 - name: enable and start mariadb
   service: name=mariadb enabled=yes state=started


### PR DESCRIPTION
Hello,

I added this change to easier the management of backup for mysql,

e.g. A machine with mariadb installed other way than this roles (manually, other role, else) can be standardized at least for backup with just one tag.

Hope you'll consider this merge,